### PR TITLE
introduce grouped version updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -9,6 +7,11 @@ updates:
     directory: "lambda/metadata-updater"
     schedule:
       interval: "daily"
+    groups:
+      # AWS SDK for Go v2 関連のバージョンアップをまとめる
+      aws-sdk:
+        patterns:
+          - github.com/aws/aws-sdk-go-v2
 
   - package-ecosystem: "docker"
     directory: "lambda/metadata-updater"


### PR DESCRIPTION
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/