### PR TITLE
feature/s3/managerからfeature/s3/transfermanagerへ移行

### DIFF
--- a/lambda/metadata-updater/go.mod
+++ b/lambda/metadata-updater/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/aws/aws-lambda-go v1.54.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.12
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4
 	github.com/aws/smithy-go v1.24.3
 	github.com/shogo82148/sets3lock v0.1.0

--- a/lambda/metadata-updater/go.sum
+++ b/lambda/metadata-updater/go.sum
@@ -10,8 +10,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.12 h1:vhbHvVM9Til68SOR3Dds7zi51PaUlzexmh4Lf/uv+Ok=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.12/go.mod h1:jq4soyz7xX5bfkxVKQu1BwkopF2QbQUTs5n7iIg3D8Q=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 h1:92MfpwB6KjsPIEq9g3DniRPxOe92ew5hUz1h8W8cX7E=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15/go.mod h1:7O129SmOn4acM++3oVfTLAeHmNOsj0y7AA7zmbgnGOk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
@@ -28,8 +28,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3x
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWURB8avufQq9gFsheUgjVD9536obIknfM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0 h1:foqo/ocQ7WqKwy3FojGtZQJo0FR4vto9qnz9VaumbCo=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4 h1:5Wg8AAAnIWM2LE/0KFGqllZff96bm4dBs+uerYFfReE=

--- a/lambda/metadata-updater/main.go
+++ b/lambda/metadata-updater/main.go
@@ -17,9 +17,9 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/smithy-go"
 	"github.com/shogo82148/sets3lock"
@@ -76,8 +76,7 @@ type handler struct {
 
 	// Clients for aws services
 	s3svc      *s3.Client
-	downloader *manager.Downloader
-	uploader   *manager.Uploader
+	s3transfer *transfermanager.Client
 	ssmsvc     *ssm.Client
 
 	// full paths for tools
@@ -94,8 +93,7 @@ func newHandler(ctx context.Context) (*handler, error) {
 		return nil, err
 	}
 	s3svc := s3.NewFromConfig(cfg)
-	downloader := manager.NewDownloader(s3svc)
-	uploader := manager.NewUploader(s3svc)
+	s3transfer := transfermanager.New(s3svc)
 	ssmsvc := ssm.NewFromConfig(cfg)
 
 	// lookup executables
@@ -122,8 +120,7 @@ func newHandler(ctx context.Context) (*handler, error) {
 		depth:           3, // $distribution/$releasever/$basearch
 
 		s3svc:      s3svc,
-		downloader: downloader,
-		uploader:   uploader,
+		s3transfer: s3transfer,
 		ssmsvc:     ssmsvc,
 		rpm:        rpm,
 		gpg:        gpg,
@@ -447,9 +444,10 @@ func (c *myContext) downloadRPM(ctx context.Context, record events.S3EventRecord
 	}
 
 	log.Printf("downloading %s from %s", record.S3.Object.Key, record.S3.Bucket.Name)
-	_, err = c.handler.downloader.Download(ctx, f, &s3.GetObjectInput{
-		Bucket: aws.String(record.S3.Bucket.Name),
-		Key:    aws.String(record.S3.Object.Key),
+	_, err = c.handler.s3transfer.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
+		Bucket:   new(record.S3.Bucket.Name),
+		Key:      new(record.S3.Object.Key),
+		WriterAt: f,
 	})
 	if err1 := f.Close(); err == nil {
 		err = err1
@@ -519,9 +517,10 @@ func (c *myContext) downloadMetadata(ctx context.Context, repo string) error {
 	}
 	key := filepath.ToSlash(filepath.Join(repo, "repodata", "repomd.xml"))
 	log.Printf("download %s from %s", key, c.handler.outputBucket)
-	_, err = c.handler.downloader.Download(ctx, f, &s3.GetObjectInput{
-		Bucket: aws.String(c.handler.outputBucket),
-		Key:    aws.String(key),
+	_, err = c.handler.s3transfer.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
+		Bucket:   new(c.handler.outputBucket),
+		Key:      new(key),
+		WriterAt: f,
 	})
 	if err1 := f.Close(); err == nil {
 		err = err1
@@ -552,9 +551,10 @@ func (c *myContext) downloadMetadata(ctx context.Context, repo string) error {
 			return err
 		}
 		log.Printf("download %s from %s", key, c.handler.outputBucket)
-		_, err = c.handler.downloader.Download(ctx, f, &s3.GetObjectInput{
-			Bucket: aws.String(c.handler.outputBucket),
-			Key:    aws.String(key),
+		_, err = c.handler.s3transfer.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
+			Bucket:   new(c.handler.outputBucket),
+			Key:      new(key),
+			WriterAt: f,
 		})
 		if err1 := f.Close(); err == nil {
 			err = err1
@@ -640,11 +640,11 @@ func (c *myContext) uploadMetadata(ctx context.Context, repo string) error {
 		key := filepath.ToSlash(rel)
 		ext := filepath.Ext(path)
 		log.Printf("uploading %s to %s", key, c.handler.outputBucket)
-		_, err = c.handler.uploader.Upload(ctx, &s3.PutObjectInput{
-			Bucket:      aws.String(c.handler.outputBucket),
-			Key:         aws.String(key),
-			ACL:         s3types.ObjectCannedACLPublicRead,
-			ContentType: aws.String(mime.TypeByExtension(ext)),
+		_, err = c.handler.s3transfer.UploadObject(ctx, &transfermanager.UploadObjectInput{
+			Bucket:      new(c.handler.outputBucket),
+			Key:         new(key),
+			ACL:         tmtypes.ObjectCannedACLPublicRead,
+			ContentType: new(mime.TypeByExtension(ext)),
 			Body:        f,
 		})
 		if err != nil {
@@ -666,11 +666,11 @@ func (c *myContext) uploadMetadata(ctx context.Context, repo string) error {
 	key := filepath.ToSlash(filepath.Join(repo, "repodata", "repomd.xml"))
 	ext := filepath.Ext(".xml")
 	log.Printf("uploading %s to %s", key, c.handler.outputBucket)
-	_, err = c.handler.uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket:      aws.String(c.handler.outputBucket),
-		Key:         aws.String(key),
-		ACL:         s3types.ObjectCannedACLPublicRead,
-		ContentType: aws.String(mime.TypeByExtension(ext)),
+	_, err = c.handler.s3transfer.UploadObject(ctx, &transfermanager.UploadObjectInput{
+		Bucket:      new(c.handler.outputBucket),
+		Key:         new(key),
+		ACL:         tmtypes.ObjectCannedACLPublicRead,
+		ContentType: new(mime.TypeByExtension(ext)),
 		Body:        f,
 	})
 	if err != nil {
@@ -710,11 +710,11 @@ func (c *myContext) uploadRPM(ctx context.Context, repo string) error {
 
 		key := filepath.ToSlash(rel)
 		log.Printf("uploading %s to %s", key, c.handler.outputBucket)
-		_, err = c.handler.uploader.Upload(ctx, &s3.PutObjectInput{
-			Bucket:      aws.String(c.handler.outputBucket),
-			Key:         aws.String(key),
-			ACL:         s3types.ObjectCannedACLPublicRead,
-			ContentType: aws.String(mime.TypeByExtension(ext)),
+		_, err = c.handler.s3transfer.UploadObject(ctx, &transfermanager.UploadObjectInput{
+			Bucket:      new(c.handler.outputBucket),
+			Key:         new(key),
+			ACL:         tmtypes.ObjectCannedACLPublicRead,
+			ContentType: new(mime.TypeByExtension(ext)),
 			Body:        f,
 		})
 		if err != nil {


### PR DESCRIPTION
feature/s3/managerはdeprecatedになってしまいました。
後継であるfeature/s3/transfermanagerへ移行します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS SDK for Go dependencies to newer versions, including a migration to the S3 transfer manager library for improved compatibility and performance.
  * Refactored internal file transfer operations to align with the updated AWS SDK architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->