### PR TITLE
fluent-bit-rpm用のIAMロールを削除

### DIFF
--- a/cloudformation/users-template.yaml
+++ b/cloudformation/users-template.yaml
@@ -320,8 +320,6 @@ Resources:
                 Action: "s3:*"
                 Resource: arn:aws:s3:::shogo82148-rpm-temporary/*
 Outputs:
-  FluentBitRole:
-    Value: !GetAtt FluentBitRole.Arn
   NginxRole:
     Value: !GetAtt NginxRole.Arn
   H2ORoleRole:

--- a/cloudformation/users-template.yaml
+++ b/cloudformation/users-template.yaml
@@ -2,36 +2,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: upload users for shogo private rpm repository
 
 Resources:
-  # https://github.com/shogo82148/fluent-bit-rpm
-  FluentBitRole:
-    Type: AWS::IAM::Role
-    Properties:
-      # trust policy for using https://github.com/fuller-inc/actions-aws-assume-role
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: arn:aws:iam::053160724612:root
-            Action:
-              - "sts:AssumeRole"
-            Condition:
-              StringEquals:
-                "sts:ExternalId": shogo82148/fluent-bit-rpm
-          - Effect: Allow
-            Principal:
-              AWS: arn:aws:iam::053160724612:root
-            Action:
-              - "sts:TagSession"
-      Policies:
-        - PolicyName: upload
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action: "s3:*"
-                Resource: arn:aws:s3:::shogo82148-rpm-temporary/*
-
   # https://github.com/shogo82148/nginx-rpm
   NginxRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
https://github.com/shogo82148/fluent-bit-rpm/commit/f40dc5d3ef34b8deb67a05fefefed4bfb52c4ca8
公式のサポートが拡充してきたので、サポートを停止します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused infrastructure role to streamline deployment configuration.
  * Removed the previously exported reference to that role’s identifier; downstream consumers should no longer rely on that export.
  * No other role resources or exports were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->