### PR TITLE
server-starterをAWSネイティブのOIDCに移行

### DIFF
--- a/cloudformation/users-template.yaml
+++ b/cloudformation/users-template.yaml
@@ -36,23 +36,19 @@ Resources:
   ServerStarterRole:
     Type: AWS::IAM::Role
     Properties:
-      # trust policy for using https://github.com/fuller-inc/actions-aws-assume-role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
-              AWS: arn:aws:iam::053160724612:root
+              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com"
             Action:
-              - "sts:AssumeRole"
+              - "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                "sts:ExternalId": shogo82148/server-starter
-          - Effect: Allow
-            Principal:
-              AWS: arn:aws:iam::053160724612:root
-            Action:
-              - "sts:TagSession"
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": "repo:shogo82148/server-starter:*"
       Policies:
         - PolicyName: upload
           PolicyDocument:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment authentication configuration to use GitHub OIDC federation, enhancing security for automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->