### PR TITLE
migrate sqldef-rpm to AWS native OIDC federation

### DIFF
--- a/cloudformation/users-template.yaml
+++ b/cloudformation/users-template.yaml
@@ -147,23 +147,20 @@ Resources:
   SqldefRole:
     Type: AWS::IAM::Role
     Properties:
-      # trust policy for using https://github.com/fuller-inc/actions-aws-assume-role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
-              AWS: arn:aws:iam::053160724612:root
+              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/tok\
+                en.actions.githubusercontent.com"
             Action:
-              - "sts:AssumeRole"
+              - "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                "sts:ExternalId": shogo82148/sqldef-rpm
-          - Effect: Allow
-            Principal:
-              AWS: arn:aws:iam::053160724612:root
-            Action:
-              - "sts:TagSession"
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": "repo:shogo82148/sqldef-rpm:*"
       Policies:
         - PolicyName: upload
           PolicyDocument:


### PR DESCRIPTION
ref. https://github.com/shogo82148/sqldef-rpm/pull/442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated authentication configuration to use GitHub OIDC federated identity for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->